### PR TITLE
Fix DateTime is not output in parsing result

### DIFF
--- a/jmaseis/common.go
+++ b/jmaseis/common.go
@@ -25,6 +25,11 @@ func (dateTime *DateTime) UnmarshalXML(d *xml.Decoder, start xml.StartElement) e
 	return nil
 }
 
+func (dateTime *DateTime) MarshalJSON() ([]byte, error) {
+	t := time.Time(*dateTime)
+	return json.Marshal(t)
+}
+
 func (m *MagnitudeValue) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
 	var s string
 	if err := d.DecodeElement(&s, &start); err != nil {


### PR DESCRIPTION
Fix #4 

```sh
$ go run main.go parse examples/32-35_01_02_100514_VXSE52.xml  | jq .
{
  "Control": {
    "Title": "震源に関する情報",
    "DateTime": "2009-10-01T04:48:03Z",
    "Status": "訓練",
    "EditorialOffice": "気象庁本庁",
    "PublishingOffice": [
      "気象庁"
    ]
  },
  "Head": {
    "Title": "震源に関する情報",
    "ReportDateTime": "2009-10-01T13:48:00+09:00",
    "TargetDateTime": "2009-10-01T13:48:00+09:00",
    "ValidDateTime": "0001-01-01T00:00:00Z",
    "EventID": "20091001134500",
    "InfoType": "発表",
    "Serial": "",
    "InfoKind": "震源速報",
    "InfoKindVersion": "1.0_0",
    "Headline": {
      "Text": "　１日１３時４５分ころ、地震がありました。"
    }
  },
  "Body": {
    "Earthquake": [
      {
        "OriginTime": "2009-10-01T13:45:00+09:00",
        "ArrivalTime": "2009-10-01T13:45:00+09:00",
        "Hypocenter": {
          "Area": {
            "Name": "駿河湾",
            "Code": {
              "Type": "震央地名",
              "Name": "485"
            },
            "Coordinate": [
              {
                "Datum": "日本測地系",
                "Description": "北緯３４．８度　東経１３８．５度　深さ　１０ｋｍ",
                "Value": "+34.8+138.5-10000/"
              }
            ],
            "DetailedName": ""
          },
          "Source": ""
        },
        "Magnitude": [
          {
            "Type": "Mj",
            "Condition": "",
            "Description": "Ｍ６．６",
            "Value": 6.6
          }
        ]
      }
    ],
    "Intensity": {
      "Observation": {
        "CodeDefine": {
          "Type": null
        },
        "MaxInt": "",
        "Pref": null
      }
    },
    "Text": "",
    "Comments": [
      {
        "ForecastComment": {
          "CodeType": "固定付加文",
          "Text": "この地震による津波の心配はありません。",
          "Code": "0203"
        },
        "VarComment": {
          "CodeType": "",
          "Text": "",
          "Code": ""
        },
        "FreeFormComment": ""
      }
    ],
    "Tsunami": {
      "Release": "",
      "Observation": {
        "CodeDefine": {
          "Type": null
        },
        "Item": null
      },
      "Estimation": {
        "CodeDefine": {
          "Type": null
        },
        "Item": null
      },
      "Forecast": {
        "CodeDefine": {
          "Type": null
        },
        "Item": null
      }
    }
  }
}

```

※ XML ファイルは [気象庁防災情報XMLフォーマット ｜ 技術資料](https://xml.kishou.go.jp/tec_material.html) から